### PR TITLE
Small Error in MOTD System

### DIFF
--- a/ulx/lua/ulx/modules/sh/menus.lua
+++ b/ulx/lua/ulx/modules/sh/menus.lua
@@ -35,7 +35,7 @@ if ULib.fileExists( "lua/ulx/modules/cl/motdmenu.lua" ) or ulx.motdmenu_exists t
 		end
 
 		if GetConVarString( "ulx_showMotd" ) == "0" then
-			ULib.tsay( ply, "The MOTD has been disabled on this server." )
+			ULib.tsay( calling_ply, "The MOTD has been disabled on this server." )
 			return
 		end
 


### PR DESCRIPTION
fixing a small error where all players get a message if a player requests the MOTD if its disabled on the server

As you can see in the diff it should be calling_ply not ply