### PR TITLE
Update xgui_server.lua

### DIFF
--- a/ulx/lua/ulx/modules/xgui_server.lua
+++ b/ulx/lua/ulx/modules/xgui_server.lua
@@ -149,7 +149,7 @@ function xgui.init()
 			local chunks = {}
 			for _, dtype in ipairs( datatypes ) do
 				if xgui.dataTypes[dtype] then
-					data = xgui.dataTypes[dtype]
+					local data = xgui.dataTypes[dtype]
 					if ULib.ucl.query( ply, data.access ) then
 						local t = data.getData()
 						local size = data.maxchunk or 0 --Split the table into "chunks" of per-datatype specified size to even out data flow. 0 to disable


### PR DESCRIPTION
If NOT set to local, it causes problems with addons that use the GLOBAL data variable for holding DATA... This is the issue with my networking system which uses networking and data globals where data = data || { }; on my end but others have had issues with this causing it to overwrite my data table each time it is called.

This fix doesn't cause any negative side-effects with ULX that I saw and allows my networking system to work for those using it.