### PR TITLE
Update UTime NW Methods

### DIFF
--- a/utime/lua/autorun/sh_utime.lua
+++ b/utime/lua/autorun/sh_utime.lua
@@ -12,7 +12,7 @@ function meta:GetUTime()
 end
 
 function meta:SetUTime( num )
-	self:GetNWFloat( "TotalUTime", num )
+	self:SetNWFloat( "TotalUTime", num )
 end
 
 function meta:GetUTimeStart()
@@ -20,7 +20,7 @@ function meta:GetUTimeStart()
 end
 
 function meta:SetUTimeStart( num )
-	self:GetNWFloat( "UTimeStart", num )
+	self:SetNWFloat( "UTimeStart", num )
 end
 
 function meta:GetUTimeSessionTime()

--- a/utime/lua/autorun/sh_utime.lua
+++ b/utime/lua/autorun/sh_utime.lua
@@ -8,19 +8,19 @@ local meta = FindMetaTable( "Player" )
 if not meta then return end
 
 function meta:GetUTime()
-	return self:GetNWInt( "TotalUTime" )
+	return self:GetNWFloat( "TotalUTime" )
 end
 
 function meta:SetUTime( num )
-	self:SetNWInt( "TotalUTime", num )
+	self:GetNWFloat( "TotalUTime", num )
 end
 
 function meta:GetUTimeStart()
-	return self:GetNWInt( "UTimeStart" )
+	return self:GetNWFloat( "UTimeStart" )
 end
 
 function meta:SetUTimeStart( num )
-	self:SetNWInt( "UTimeStart", num )
+	self:GetNWFloat( "UTimeStart", num )
 end
 
 function meta:GetUTimeSessionTime()


### PR DESCRIPTION
GetNWInt doesn't accepts floats anymore, I've changed it to use GetNWFloat.
Yet, this doesn't fixes it not storing the Total time after server restarts/crashes, nor it showing the same time for Session time & Total time.